### PR TITLE
Change default log message to empty string

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -206,7 +206,7 @@ func NewWithConfig(logger *slog.Logger, config Config) gin.HandlerFunc {
 		}
 
 		level := config.DefaultLevel
-		msg := "Incoming request"
+		msg := ""
 		if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
 			level = config.ClientErrorLevel
 			msg = c.Errors.String()


### PR DESCRIPTION
The previous value did not hold any valuable information.